### PR TITLE
fix: Remove lovable favicon meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,7 @@
     <meta property="og:title" content="zkTLS Demo - Privacy-Preserving Verification" />
     <meta property="og:description" content="Interactive demonstration showing how zkTLS verifies data without exposing personal information" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
This commit removes the `og:image`, `twitter:image`, and `twitter:site` meta tags that were pointing to 'lovable.dev' assets. This addresses the user's request to remove the lovable favicon.